### PR TITLE
REDCap UI Tweaker version 1.9.3

### DIFF
--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -2083,7 +2083,8 @@ $(function()
 <script type="text/javascript">
   $(function()
   {
-    $('a[href*="redcap.vanderbilt.edu/enduser_survey"]').parent().css('display','none')
+    $('a[href*="redcap.vanderbilt.edu/enduser_survey"],a[href*="redcap.vumc.org/enduser_survey"]')
+     .parent().css('display','none')
   })
 </script>
 <?php

--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -389,7 +389,8 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 			if ( $this->getSystemSetting( 'login-page-logo' ) != '' )
 			{
 				echo '<script type="text/javascript">$(function(){$(\'#container\')',
-				     '.css(\'background\',$(\'#container\').css(\'background\')+\',url("',
+				     '.css(\'background\',$(\'#container\').css(\'background\')' ,
+				     '.replace(\'rgba(0, 0, 0, 0)\',\'\')+\',url("',
 				     $this->escapeHTML( $this->getSystemSetting( 'login-page-logo' ) ),
 				     '") top right no-repeat\')})</script>';
 			}

--- a/alerts_simplified.php
+++ b/alerts_simplified.php
@@ -110,7 +110,9 @@ $querySurvey = $module->query( "SELECT form_name, ( SELECT form_menu_description
                                "if( confirmation_email_attachment IS NULL, 0, 1) " .
                                "confirmation_email_attachment FROM redcap_surveys rs " .
                                "WHERE survey_enabled = 1 AND confirmation_email_subject IS NOT " .
-                               "NULL AND confirmation_email_content IS NOT NULL AND project_id = ? " .
+                               "NULL AND confirmation_email_content IS NOT NULL AND " .
+                               "project_id = ? AND form_name IN ( SELECT DISTINCT form_name " .
+                               "FROM redcap_metadata WHERE project_id = rs.project_id ) " .
                                "ORDER BY ( SELECT field_order FROM redcap_metadata WHERE " .
                                "form_name = rs.form_name AND form_menu_description IS NOT NULL " .
                                "AND project_id = rs.project_id LIMIT 1 )",

--- a/alerts_simplified.php
+++ b/alerts_simplified.php
@@ -15,7 +15,7 @@ function alertsEscape( $text )
 {
 	global $svbr;
 	$text = str_replace( [ "\r\n", "\r" ], "\n", $text );
-	$text = preg_replace( "/<\\/p>( |\n|\t)*<p>/", '<br><br>', $text );
+	$text = preg_replace( "/<\\/p>( |\n|\t)*<p[^>]*>/", '<br><br>', $text );
 	$text = preg_replace( "/<\\/p>( |\n|\t)*<[ou]l>/", '<br>', $text );
 	$text = preg_replace( '/<li[^>]*>/', '<br>', $text );
 	$text = str_replace( [ '<p>', '</p>' ], '', $text );
@@ -139,6 +139,10 @@ while ( $infoAlert = $queryAlerts->fetch_assoc() )
 	}
 	$infoAlert['alert_condition'] = str_replace( "\r\n", "\n", $infoAlert['alert_condition'] );
 	$infoAlert['alert_message'] = str_replace( "\r\n", "\n", $infoAlert['alert_message'] );
+	$infoAlert['alert_message'] = preg_replace( '/ +/', ' ', $infoAlert['alert_message'] );
+	$infoAlert['alert_message'] = preg_replace( '!<br ?/>!', '<br>', $infoAlert['alert_message'] );
+	$infoAlert['alert_message'] = str_replace( ' <br>', '<br>', $infoAlert['alert_message'] );
+	$infoAlert['alert_message'] = str_replace( ' </p>', '</p>', $infoAlert['alert_message'] );
 	$listExport['alerts'][] = $infoAlert;
 }
 
@@ -155,6 +159,16 @@ while ( $infoASI = $queryASI->fetch_assoc() )
 
 while ( $infoSurvey = $querySurvey->fetch_assoc() )
 {
+	$infoSurvey['confirmation_email_content'] =
+			str_replace( "\r\n", "\n", $infoSurvey['confirmation_email_content'] );
+	$infoSurvey['confirmation_email_content'] =
+			preg_replace( '/ +/', ' ', $infoSurvey['confirmation_email_content'] );
+	$infoSurvey['confirmation_email_content'] =
+			preg_replace( '!<br ?/>!', '<br>', $infoSurvey['confirmation_email_content'] );
+	$infoSurvey['confirmation_email_content'] =
+			str_replace( ' <br>', '<br>', $infoSurvey['confirmation_email_content'] );
+	$infoSurvey['confirmation_email_content'] =
+			str_replace( ' </p>', '</p>', $infoSurvey['confirmation_email_content'] );
 	$listExport['survey'][] = $infoSurvey;
 }
 

--- a/codebook_simplified.php
+++ b/codebook_simplified.php
@@ -101,6 +101,7 @@ while ( $infoFDL = $queryFDL->fetch_assoc() )
 			$fdlEvents[ $i ] = $listEventNames[ $fdlEventID ];
 		}
 	}
+	$infoFDL['control_condition'] = str_replace( "\r\n", "\n", $infoFDL['control_condition'] );
 	$listExport['forms'][ $infoFDL['form_name'] ]['fdl'][] =
 			[ 'condition' => $infoFDL['control_condition'], 'events' => $fdlEvents ];
 }

--- a/extmod_simplified.php
+++ b/extmod_simplified.php
@@ -68,9 +68,10 @@ $queryModules = $module->query( "SELECT em.directory_prefix module, if( project_
                                 "`value` = 'true' AND project_id IS NULL ) ) AND " .
                                 "em.external_module_id NOT IN ( SELECT external_module_id FROM " .
                                 "redcap_external_module_settings WHERE `key` = 'enabled' AND " .
-                                "`value` = 'false' AND project_id = ? ) AND ( (project_id IS " .
-                                "NULL AND `key` LIKE concat('p',?,'-%')) OR project_id = ? ) AND " .
-                                "`key` <> 'enabled' AND ( `key` <> " .
+                                "`value` = 'false' AND project_id = ? ) AND ( (project_id IS NULL" .
+                                " AND `key` COLLATE utf8mb4_unicode_ci LIKE concat('p',?,'-%')) " .
+                                "COLLATE utf8mb4_unicode_ci OR project_id = ? ) " .
+                                "AND `key` <> 'enabled' AND ( `key` <> " .
                                 "'reserved-hide-from-non-admins-in-project-list' OR `value` <> " .
                                 "'false' ) ORDER BY module, setting",
                                [ $module->getProjectID(), $module->getProjectID(),

--- a/instrument_simplified.php
+++ b/instrument_simplified.php
@@ -204,7 +204,7 @@ foreach ( $listNew['arms'] as $i => $itemNewArm )
 			$itemOldEvent['deleted'] = true;
 			$itemNewArm['events'][] = $itemOldEvent;
 		}
-		if ( $listData['max_events'] < count( $itemNewArm['events'] ) )
+		if ( $listData['max_events'] < count( $itemNewArm['events'] ?? [] ) )
 		{
 			$listData['max_events'] = count( $itemNewArm['events'] );
 		}
@@ -337,7 +337,7 @@ foreach ( $listData['arms'] as $infoArm )
                  ( $infoEvent['repeat'] == 1 ? ' &#10227;' : '' ); ?></th>
 <?php
 	}
-	for ( $i = count( $infoArm['events'] ); $i < $listData['max_events']; $i++ )
+	for ( $i = count( $infoArm['events'] ?? [] ); $i < $listData['max_events']; $i++ )
 	{
 ?>
   <th style="<?php echo $armHdrStyle; ?>"></th>

--- a/reports_simplified.php
+++ b/reports_simplified.php
@@ -33,17 +33,22 @@ $queryReports = $module->query( "SELECT r.*, ( SELECT group_concat( field_name O
                                 "report_id = r.report_id AND limiter_operator IS NULL ) fields, " .
                                 "( SELECT trim(substring(group_concat( concat( " .
                                 "limiter_group_operator, ' ', field_name, ' ', CASE " .
-                                "limiter_operator WHEN 'E' THEN '=' WHEN 'NE' THEN '<>' ELSE " .
-                                "limiter_operator END, ' ', limiter_value ) ORDER BY field_order " .
-                                "SEPARATOR ' ' ),4)) FROM redcap_reports_fields WHERE " .
-                                "report_id = 3 AND limiter_operator IS NOT NULL ) simple_logic, " .
+                                "limiter_operator WHEN 'E' THEN '=' WHEN 'NE' THEN '<>' " .
+                                "WHEN 'LT' THEN '<' WHEN 'LTE' THEN '<=' WHEN 'GT' THEN '>' " .
+                                "WHEN 'GTE' THEN '>=' ELSE limiter_operator END, ' ', CASE " .
+                                "limiter_operator WHEN 'LT' THEN '' WHEN 'LTE' THEN '' WHEN 'GT' " .
+                                "THEN '' WHEN 'GTE' THEN '' ELSE '\'' END, limiter_value, CASE " .
+                                "limiter_operator WHEN 'LT' THEN '' WHEN 'LTE' THEN '' WHEN 'GT' " .
+                                "THEN '' WHEN 'GTE' THEN '' ELSE '\'' END ) ORDER BY field_order " .
+                                "SEPARATOR ' ' ),4)) FROM redcap_reports_fields WHERE report_id =" .
+                                " r.report_id AND limiter_operator IS NOT NULL ) simple_logic, " .
                                 "( SELECT group_concat( role_name SEPARATOR ', ' ) FROM " .
                                 "redcap_reports_access_roles rr JOIN redcap_user_roles ur ON " .
                                 "rr.role_id = ur.role_id WHERE rr.report_id = r.report_id ) " .
                                 "access_roles, " .
                                 "( SELECT group_concat( role_name SEPARATOR ', ' ) FROM " .
-                                "redcap_reports_edit_access_roles rr JOIN redcap_user_roles ur ON " .
-                                "rr.role_id = ur.role_id WHERE rr.report_id = r.report_id ) " .
+                                "redcap_reports_edit_access_roles rr JOIN redcap_user_roles ur ON" .
+                                " rr.role_id = ur.role_id WHERE rr.report_id = r.report_id ) " .
                                 "edit_access_roles, " .
                                 "( SELECT 1 FROM redcap_reports_access_users " .
                                 "WHERE report_id = r.report_id ) access_users, " .
@@ -55,7 +60,7 @@ $queryReports = $module->query( "SELECT r.*, ( SELECT group_concat( field_name O
                                 "WHERE report_id = r.report_id ) edit_access_dags " .
                                 "FROM redcap_reports r " .
                                 "WHERE project_id = ? ORDER BY report_order",
-                               [ $module->getProjectID() ] );
+                                [ $module->getProjectID() ] );
 
 if ( $reportsNS )
 {


### PR DESCRIPTION
* Bug fixes:
  * Corrected extra login page logo so it displays in Chrome browsers.
  * Normalise newlines in form display logic to avoid phantom differences in the codebook simplified view difference highlighting.
  * Improvements to handling of spaces and newlines in alert message in alerts simplified view to avoid phantom differences.
  * Exclude survey confirmation emails from the alerts simplified view where an entry remains in the database after the corresponding form has been deleted.
  * Ensure the instrument/event simplified view loads without errors on longitudinal projects even if no instrument/event mappings have been defined.
  * Corrected a mismatched collation issue on the external modules simplified view.
  * Amended the query to retrieve the report simple logic on the reports simplified view.
  * Amended the hide 'suggest a new feature' link option to support new versions of REDCap.