### PR TITLE
REDCap UI Tweaker version 1.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,11 @@ column names are `code` and `label`, otherwise the query will not function. Also
 For best results, the SQL query should return all possible options outside of a record context<br>
 (where \[record-name\] = '') and only limit to a subset (if required) within a record context.
 
-Note that for performance reasons, the number of options returned by an `@SQLCHECKBOX` field may be
-limited if the query returns more than 15 options.
+Due to the field being based upon the SQL drop down field type, the module has to amend the query to
+return all the individual options plus all the combinations which are in use at a given time as
+additional options. If many different combinations have been selected for various records this may
+have an impact on performance as all these combinations will have to be loaded for the field. The
+maximum number of options for an `@SQLCHECKBOX` field is therefore limited to 60.
 
 *The previous implementation of* `@SQLCHECKBOX` *where the tag is applied to checkbox fields is now
 deprecated and will be removed in a future version of this module.*

--- a/README.md
+++ b/README.md
@@ -162,14 +162,17 @@ in URL-encoded or base64 format, which can be indicated by prefixing the data as
 Allow use of the **@SQLCHECKBOX** action tag for SQL fields, which will replace the drop-down list
 with a checkbox for each option similar to a checkbox field.
 
-When writing an SQL query for use with the *@SQLCHECKBOX* action tag, ensure that the returned
+When writing an SQL query for use with the `@SQLCHECKBOX` action tag, ensure that the returned
 column names are `code` and `label`, otherwise the query will not function. Also note that the
-*@SQLCHECKBOX* action tag does not work with the *@IF* action tag.
+`@SQLCHECKBOX` action tag does not work with the `@IF` action tag.
 
 For best results, the SQL query should return all possible options outside of a record context<br>
 (where \[record-name\] = '') and only limit to a subset (if required) within a record context.
 
-*The previous implementation of @SQLCHECKBOX where the tag is applied to checkbox fields is now
+Note that for performance reasons, the number of options returned by an `@SQLCHECKBOX` field may be
+limited if the query returns more than 15 options.
+
+*The previous implementation of* `@SQLCHECKBOX` *where the tag is applied to checkbox fields is now
 deprecated and will be removed in a future version of this module.*
 
 ### Static form variable names

--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -28,6 +28,9 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 	// (In some contexts we want to allow cell-splitting so there isn't too much content in a cell.)
 	const SVBR_MAX_LINES = 25;
 
+	// Maximum number of checkboxes for SQLCHECKBOX fields.
+	const MAX_SQLCHECKBOX_OPTIONS = 60;
+
 	private $customAlerts;
 	private $customReports;
 	private $extModSettings;
@@ -3685,7 +3688,7 @@ $(function()
 			"-- END redcap_ui_tweaker\n" .
 			rtrim( $_POST['element_enum'], " \n\r\t;" ) .
 			"\n-- BEGIN redcap_ui_tweaker\n" .
-			") redcap_ui_tweaker_sqy LIMIT 60" .
+			") redcap_ui_tweaker_sqy LIMIT " . self::MAX_SQLCHECKBOX_OPTIONS .
 			"), redcap_ui_tweaker_cb AS ( SELECT cast(concat(',',redcap_ui_tweaker_qy.`code`) " .
 			"AS CHAR(255)) AS codestr, redcap_ui_tweaker_qy.`code`, cast(concat(', '," .
 			"redcap_ui_tweaker_qy.`label`) AS CHAR(255)) AS `label` FROM redcap_ui_tweaker_qy " .

--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -2892,7 +2892,7 @@ $(function()
             var vClickedField = $(this).find('input').attr('data-sqlcb-field')
             $('select[name="' + vClickedField + '"]')
             .val( $('input[data-sqlcb-field="' + vClickedField + '"]:checked')
-                  .map(function(){return $(this).attr('data-sqlcb-val')}).toArray().join(',') )
+                .map(function(){return $(this).attr('data-sqlcb-val')}).toArray().sort().join(',') )
           })
           if ( vIsVertical )
           {
@@ -3641,10 +3641,12 @@ $(function()
 	{
 		unset( $_POST['dropdown_autocomplete'] );
 		$_POST['element_enum'] =
-			"SELECT * FROM ( WITH RECURSIVE redcap_ui_tweaker_qy AS (\n" .
+			"SELECT * FROM ( WITH RECURSIVE redcap_ui_tweaker_qy AS ( " .
+			"SELECT * FROM (\n" .
 			"-- END redcap_ui_tweaker\n" .
 			rtrim( $_POST['element_enum'], " \n\r\t;" ) .
 			"\n-- BEGIN redcap_ui_tweaker\n" .
+			") redcap_ui_tweaker_sqy LIMIT 15" .
 			"), redcap_ui_tweaker_cb AS ( SELECT cast(concat(',',redcap_ui_tweaker_qy.`code`) " .
 			"AS CHAR(255)) AS codestr, redcap_ui_tweaker_qy.`code`, cast(concat(', '," .
 			"redcap_ui_tweaker_qy.`label`) AS CHAR(255)) AS `label` FROM redcap_ui_tweaker_qy " .

--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -202,6 +202,30 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 				$GLOBALS['lang']['dataqueries_309'] = $dqCustomBodyDRW;
 			}
 
+			// If a submission which includes @SQLCHECKBOX fields, ensure that the selected options
+			// are allowed to be submitted.
+			$listValuesSQLChkbx = [];
+			if ( $_GET['page'] != '' && ! empty( $_POST ) &&
+			     $this->getSystemSetting( 'sql-checkbox' ) )
+			{
+				foreach ( $_POST as $postField => $postVal )
+				{
+					if ( substr( $postField, -22 ) == ':uitweaker-sqlcheckbox' )
+					{
+						$listValuesSQLChkbx[] = $_POST[ substr( $postField, 0, -22 ) ];
+					}
+				}
+			}
+			if ( empty( $listValuesSQLChkbx ) )
+			{
+				$this->removeProjectSetting( 'sql-checkbox-submittedvalues' );
+			}
+			else
+			{
+				$this->setProjectSetting( 'sql-checkbox-submittedvalues',
+				                          json_encode( $listValuesSQLChkbx ) );
+			}
+
 			// [DEPRECATED] Check if the @SQLCHECKBOX action tag is enabled and provide its
 			// functionality if so.
 			if($_GET['page'] != '' && $this->getSystemSetting( 'sql-checkbox' ))
@@ -2890,9 +2914,15 @@ $(function()
           vOptionLabel.click( function()
           {
             var vClickedField = $(this).find('input').attr('data-sqlcb-field')
-            $('select[name="' + vClickedField + '"]')
-            .val( $('input[data-sqlcb-field="' + vClickedField + '"]:checked')
-                .map(function(){return $(this).attr('data-sqlcb-val')}).toArray().sort().join(',') )
+            var vNewValue = $('input[data-sqlcb-field="' + vClickedField + '"]:checked')
+                  .map(function(){return $(this).attr('data-sqlcb-val')}).toArray().sort().join(',')
+            if ( $('select[name="' + vClickedField + '"] ' +
+                   'option[value="' + vNewValue + '"]').length == 0 )
+            {
+              $('select[name="' + vClickedField + '"]')
+              .append('<option value="' + vNewValue + '">' + vNewValue + '</option>')
+            }
+            $('select[name="' + vClickedField + '"]').val( vNewValue )
           })
           if ( vIsVertical )
           {
@@ -2908,6 +2938,8 @@ $(function()
         }
         vContainerField.after( vContainerChkbx )
         vContainerField.css('display','none')
+        vSQLField.after( '<input type="hidden" name="' + vFieldName +
+                         ':uitweaker-sqlcheckbox" value="1">' )
       }
     },100)
   })
@@ -3641,12 +3673,19 @@ $(function()
 	{
 		unset( $_POST['dropdown_autocomplete'] );
 		$_POST['element_enum'] =
-			"SELECT * FROM ( WITH RECURSIVE redcap_ui_tweaker_qy AS ( " .
+			"SELECT * FROM ( WITH RECURSIVE redcap_ui_tweaker_ev AS ( SELECT DISTINCT `value` " .
+			"AS v FROM [data-table] WHERE project_id = [project-id] AND field_name = '" .
+			preg_replace( '/[^A-Za-z0-9_]/', '', $_POST['field_name'] ) .
+			"' UNION SELECT v FROM redcap_external_module_settings JOIN JSON_TABLE( `value`, " .
+			"'$[*]' COLUMNS ( v VARCHAR(255) PATH '$' ) ) redcap_ui_tweaker_sv WHERE " .
+			"external_module_id = (SELECT external_module_id FROM redcap_external_modules WHERE " .
+			"directory_prefix = 'redcap_ui_tweaker' LIMIT 1) AND project_id = [project-id] AND " .
+			"`key` = 'sql-checkbox-submittedvalues' ), redcap_ui_tweaker_qy AS (" .
 			"SELECT * FROM (\n" .
 			"-- END redcap_ui_tweaker\n" .
 			rtrim( $_POST['element_enum'], " \n\r\t;" ) .
 			"\n-- BEGIN redcap_ui_tweaker\n" .
-			") redcap_ui_tweaker_sqy LIMIT 15" .
+			") redcap_ui_tweaker_sqy LIMIT 60" .
 			"), redcap_ui_tweaker_cb AS ( SELECT cast(concat(',',redcap_ui_tweaker_qy.`code`) " .
 			"AS CHAR(255)) AS codestr, redcap_ui_tweaker_qy.`code`, cast(concat(', '," .
 			"redcap_ui_tweaker_qy.`label`) AS CHAR(255)) AS `label` FROM redcap_ui_tweaker_qy " .
@@ -3654,7 +3693,10 @@ $(function()
 			"`code`), redcap_ui_tweaker_qy.`code`, concat(redcap_ui_tweaker_cb.`label`,', '," .
 			"redcap_ui_tweaker_qy.`label`) FROM redcap_ui_tweaker_cb JOIN redcap_ui_tweaker_qy " .
 			"WHERE locate(concat(',',redcap_ui_tweaker_qy.`code`),redcap_ui_tweaker_cb.codestr) " .
-			"= 0 AND redcap_ui_tweaker_cb.`code` < redcap_ui_tweaker_qy.`code` ) " .
+			"= 0 AND redcap_ui_tweaker_cb.`code` < redcap_ui_tweaker_qy.`code` AND " .
+			"concat(redcap_ui_tweaker_cb.codestr,',',redcap_ui_tweaker_qy.`code`) " .
+			"IN ( SELECT substring(concat(',',v),1,length(concat(redcap_ui_tweaker_cb.codestr," .
+			"',',redcap_ui_tweaker_qy.`code`))) FROM redcap_ui_tweaker_ev ) ) " .
 			"SELECT substring(codestr,2) AS `code`, substring(`label`,3) AS `label` " .
 			"FROM redcap_ui_tweaker_cb ) redcap_ui_tweaker_out";
 	}

--- a/config.json
+++ b/config.json
@@ -436,7 +436,7 @@
 		},
 		{
 			"tag" : "@SQLCHECKBOX",
-			"description" : "On SQL fields, replace the drop-down with checkboxes. When writing an SQL query for use with the @SQLCHECKBOX action tag, ensure that the returned column names are 'code' and 'label', otherwise the query will not function. Also note that this action tag does not work with @IF, and that for performance reasons the number of options returned may be limited if the query returns more than 15 options."
+			"description" : "On SQL fields, replace the drop-down with checkboxes. When writing an SQL query for use with the @SQLCHECKBOX action tag, ensure that the returned column names are 'code' and 'label', otherwise the query will not function. Also note that this action tag does not work with @IF, and that a maximum of 60 options will be returned."
 		}
 	]
 }

--- a/config.json
+++ b/config.json
@@ -436,7 +436,7 @@
 		},
 		{
 			"tag" : "@SQLCHECKBOX",
-			"description" : "On SQL fields, replace the drop-down with checkboxes. When writing an SQL query for use with the @SQLCHECKBOX action tag, ensure that the returned column names are 'code' and 'label', otherwise the query will not function. Also note that this action tag does not work with @IF."
+			"description" : "On SQL fields, replace the drop-down with checkboxes. When writing an SQL query for use with the @SQLCHECKBOX action tag, ensure that the returned column names are 'code' and 'label', otherwise the query will not function. Also note that this action tag does not work with @IF, and that for performance reasons the number of options returned may be limited if the query returns more than 15 options."
 		}
 	]
 }


### PR DESCRIPTION
* Amended the new `@SQLCHECKBOX` action tag implementation to fix a bug where options with codes in a non-sorted order would not save, to improve performance by amending the handling of option combinations and limiting the maximum number of options to 60.