### PR TITLE
REDCap UI Tweaker version 1.10.2

### DIFF
--- a/.github/workflows/redcap-module-tests.yml
+++ b/.github/workflows/redcap-module-tests.yml
@@ -15,6 +15,7 @@ jobs:
     with:
       RC_COMMUNITY_USERNAME: ${{ vars.RC_COMMUNITY_USERNAME }}
       RC_INSTALLED_VERSION: ${{ vars.RC_INSTALLED_VERSION }}
+      USERS_NAMES: ${{ vars.USERS_NAMES }}
     secrets:
       RC_COMMUNITY_PASSWORD: ${{ secrets.RC_COMMUNITY_PASSWORD }}
 

--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -981,10 +981,17 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 					{
 						$submitOptions = substr( $submitOptions, 1, -1 );
 					}
+					// If data is being added using the Instance Table external module, only allow
+					// blank submit options to be set (i.e. prohibit saving).
+					if ( $submitOptions != '' && isset( $_GET['extmod_instance_table'] ) )
+					{
+						continue;
+					}
 					$customSubmit = $this->rearrangeSubmitOptions( $submitOptions );
 				}
 			}
-			if ( ! $customSubmit && $this->getProjectSetting( 'submit-option' ) != '' )
+			if ( ! $customSubmit && ! isset( $_GET['extmod_instance_table'] ) &&
+			     $this->getProjectSetting( 'submit-option' ) != '' )
 			{
 				$customSubmit =
 					$this->rearrangeSubmitOptions( $this->getProjectSetting( 'submit-option' ) );
@@ -994,7 +1001,14 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 		// selected in the module system settings (if applicable).
 		if ( ! $customSubmit )
 		{
-			if ( $this->getSystemSetting( 'submit-option-tweak' ) == '1' )
+			if ( isset( $_GET['extmod_instance_table'] ) )
+			{
+				// If data is being added using the Instance Table external module, and blank submit
+				// options have not been set on the form, then display *only* the save and exit form
+				// option.
+				$this->rearrangeSubmitOptions( 'record' );
+			}
+			elseif ( $this->getSystemSetting( 'submit-option-tweak' ) == '1' )
 			{
 				// Identify the 'Save & Go To Next Record' option and remove it.
 				$this->removeSubmitOption( 'nextrecord' );
@@ -1044,7 +1058,10 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 		}
 
 		// Check if the lock blank form option is enabled and provide it if this is a blank form.
+		// If data is being added using the Instance Table external module then *do not* display
+		// the lock blank form option.
 		if ( $this->getSystemSetting( 'lock-blank-form' ) &&
+		     ! isset( $_GET['extmod_instance_table'] ) &&
 		     ! $this->query( 'SELECT 1 FROM ' . \REDCap::getDataTable( $project_id ) .
 		                     ' WHERE project_id = ? AND event_id = ? AND record = ? AND ' .
 		                     'field_name = ? AND ifnull(instance,1) = ?',

--- a/REDCapUITweaker.php
+++ b/REDCapUITweaker.php
@@ -1370,8 +1370,9 @@ class REDCapUITweaker extends \ExternalModules\AbstractExternalModule
 
 	function getIconUrl( $icon )
 	{
-		return preg_replace( '/&pid=[1-9][0-9]*/', '',
-		                     $this->getUrl( "status_icon.php?icon=$icon" ) );
+		return preg_replace( '!^https?://[^/]*!', '',
+		                     preg_replace( '/&pid=[1-9][0-9]*/', '',
+		                                   $this->getUrl( "status_icon.php?icon=$icon" ) ) );
 	}
 
 

--- a/codebook_simplified.php
+++ b/codebook_simplified.php
@@ -48,6 +48,8 @@ while ( $infoCodebook = $queryCodebook->fetch_assoc() )
 			str_replace( [ "\r\n", '<br>', '<br />' ], "\n", $infoCodebook['element_label'] ?? '' );
 	$infoCodebook['element_enum'] =
 			str_replace( [ "\r\n", '<br>', '<br />' ], "\n", $infoCodebook['element_enum'] ?? '' );
+	$infoCodebook['branching_logic'] =
+			str_replace( "\r\n", "\n", $infoCodebook['branching_logic'] ?? '' );
 	$infoCodebook['misc'] = str_replace( "\r\n", "\n", $infoCodebook['misc'] ?? '' );
 	// Update legacy field type validation names.
 	if ( $infoCodebook['element_validation_type'] == 'int' )

--- a/extmod_simplified.php
+++ b/extmod_simplified.php
@@ -85,8 +85,15 @@ while ( $infoModule = $queryModules->fetch_assoc() )
 	$fetchedModuleInstance = false;
 	if ( ! isset( $listModuleInstances[ $infoModule['module'] ] ) )
 	{
-		$listModuleInstances[ $infoModule['module'] ] =
-				\ExternalModules\ExternalModules::getModuleInstance( $infoModule['module'] );
+		try
+		{
+			$listModuleInstances[ $infoModule['module'] ] =
+					\ExternalModules\ExternalModules::getModuleInstance( $infoModule['module'] );
+		}
+		catch ( \Exception $e )
+		{
+			continue;
+		}
 		$fetchedModuleInstance = true;
 		$listModuleSettings[ $infoModule['module'] ] =
 				getAllModSettings( $listModuleInstances[ $infoModule['module'] ]


### PR DESCRIPTION
* Alternate status icon URLs are now given just as the path instead of as an absolute URL including server name. This may help alleviate a bug in some versions of REDCap where the survey base URL is mistakenly used instead of the regular base URL.
* Codebook simplified view normalises line breaks in branching logic.
* External modules simplified view will skip any modules it fails to load (e.g. if a module which had been added to the project has been removed at system level). Previously this would have resulted in an error.
* Amended module behaviours when used with the Instance Table external module:
  * The *lock blank form* option is now not displayed when adding data via the Instance Table module.
  * If custom submit options are being used, only the *save and exit form* option is shown when adding data via the Instance Table module, unless blank options have been set with `@SAVEOPTIONS=''` in which case all submit options are removed as usual.